### PR TITLE
Multi-candidate vendors

### DIFF
--- a/app/controllers/ConsumerController.scala
+++ b/app/controllers/ConsumerController.scala
@@ -26,8 +26,8 @@ class ConsumerController @Inject() (val repo: ConsumerRepo, cc: ControllerCompon
       val consumer = Consumers.fromName(consumerReq.consumer)
       repo
         .persist(consumer.copy(token = sha256(consumer.token)))
-        .map { c =>
-          logger.info(s"Successfully persisted Consumer: ${c.name} id: ${c.id}")
+        .map { id =>
+          logger.info(s"Successfully persisted Consumer: ${consumer.name} with id: $id")
           Created(toJson(CreateResponse(consumer.id, consumer.token, consumer.name)))
         }
         .recover {

--- a/app/repos/ConsumerRepo.scala
+++ b/app/repos/ConsumerRepo.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 class ConsumerRepo @Inject() (val dbConfigProvider: DatabaseConfigProvider)
     extends HasDatabaseConfigProvider[JdbcProfile] {
 
-  implicit def helpersSlickGetResultUUID: GetResult[UUID] =
+  implicit def slickGetResultUUID: GetResult[UUID] =
     GetResult(r => r.nextObject.asInstanceOf[UUID])
 
   implicit def slickSetParameterUUID: SetParameter[UUID] =

--- a/app/utils/VendorProxyConfig.scala
+++ b/app/utils/VendorProxyConfig.scala
@@ -12,7 +12,5 @@ class VendorProxyConfig @Inject() (val configuration: Configuration) {
 
   def secret = configuration.get[String]("admin.token")
 
-  def consumersTable = configuration.get[String]("consumers.table")
-
   def version = configuration.get[String]("application.version")
 }

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
 unmanagedResourceDirectories in Test += baseDirectory.value / "features"
 
 packageName in Docker := "sdkman/vendor-proxy"
-dockerBaseImage := "openjdk:11"
+dockerBaseImage := "adoptopenjdk/openjdk11:jdk-11.0.10_9-debian-slim"
 dockerExposedPorts ++= Seq(9000)
 
 javaOptions in Universal ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,7 +15,6 @@ slick.dbs.default.db.password = ""
 slick.dbs.default.db.password = ${?DATABASE_PASSWORD}
 slick.dbs.default.db.connectionTestQuery = "SELECT 1"
 slick.dbs.default.db.connectionTimeout = 5000
-consumers.table = "vendors"
 
 #flyway
 play.modules.enabled += "org.flywaydb.play.PlayModule"

--- a/conf/db/migration/default/V2__create_candidates_table.sql
+++ b/conf/db/migration/default/V2__create_candidates_table.sql
@@ -1,0 +1,23 @@
+CREATE TABLE credentials
+(
+    id    serial primary key,
+    key   varchar(32),
+    token varchar(64),
+    owner varchar(100)
+);
+
+
+CREATE TABLE candidates
+(
+    id            serial primary key,
+    credential_id integer REFERENCES credentials (id),
+    name          varchar(100)
+);
+
+INSERT INTO credentials(key, token, owner)
+SELECT id, token, name
+from vendors;
+
+INSERT INTO candidates(credential_id, name)
+SELECT id, owner
+from credentials;

--- a/conf/db/migration/default/V2__create_candidates_table.sql
+++ b/conf/db/migration/default/V2__create_candidates_table.sql
@@ -1,17 +1,17 @@
 CREATE TABLE credentials
 (
-    id    serial primary key,
+    id    uuid primary key,
     key   varchar(32),
     token varchar(64),
-    owner varchar(100)
+    owner varchar(100) UNIQUE
 );
 
 
 CREATE TABLE candidates
 (
-    id            serial primary key,
-    credential_id integer REFERENCES credentials (id),
-    name          varchar(100)
+    credential_id uuid REFERENCES credentials (id),
+    name          varchar(100),
+    UNIQUE (credential_id, name)
 );
 
 INSERT INTO credentials(key, token, owner)


### PR DESCRIPTION
- Change docker base image to adoptopenjdk/openjdk11 Debian slim.
- Introduce new credentials and candidates tables.
- Use the new model for existing functionality.

Worth noting that all tests are still passing, so no functionality has degraded :tada: 